### PR TITLE
Core/Bnet: don't return last played when realm is offline

### DIFF
--- a/src/server/bnetserver/Server/Session.cpp
+++ b/src/server/bnetserver/Server/Session.cpp
@@ -483,11 +483,6 @@ uint32 Battlenet::Session::GetLastCharPlayed(std::unordered_map<std::string, Var
         auto lastPlayerChar = _accountInfo->LastPlayedCharacters.find(subRegion->string_value());
         if (lastPlayerChar != _accountInfo->LastPlayedCharacters.end())
         {
-            // don't return last played on an offline realm
-            auto realm = sRealmList->GetRealm(lastPlayerChar->second.RealmId);
-            if (realm && realm->Flags & RealmFlags::REALM_FLAG_OFFLINE)
-                return ERROR_OK;
-
             std::vector<uint8> compressed = sRealmList->GetRealmEntryJSON(lastPlayerChar->second.RealmId, _build);
 
             if (compressed.empty())

--- a/src/server/bnetserver/Server/Session.cpp
+++ b/src/server/bnetserver/Server/Session.cpp
@@ -483,6 +483,11 @@ uint32 Battlenet::Session::GetLastCharPlayed(std::unordered_map<std::string, Var
         auto lastPlayerChar = _accountInfo->LastPlayedCharacters.find(subRegion->string_value());
         if (lastPlayerChar != _accountInfo->LastPlayedCharacters.end())
         {
+            // don't return last played on an offline realm
+            auto realm = sRealmList->GetRealm(lastPlayerChar->second.RealmId);
+            if (realm && realm->Flags & RealmFlags::REALM_FLAG_OFFLINE)
+                return ERROR_OK;
+
             std::vector<uint8> compressed = sRealmList->GetRealmEntryJSON(lastPlayerChar->second.RealmId, _build);
 
             if (compressed.empty())

--- a/src/server/database/Database/Implementation/LoginDatabase.cpp
+++ b/src/server/database/Database/Implementation/LoginDatabase.cpp
@@ -97,7 +97,7 @@ void LoginDatabaseConnection::DoPrepareStatements()
     PrepareStatement(LOGIN_SEL_ACCOUNT_INFO_CONTINUED_SESSION, "SELECT username, sessionkey FROM account WHERE id = ?", CONNECTION_ASYNC);
 
     PrepareStatement(LOGIN_UPD_ACCOUNT_LOGIN_INFO, "UPDATE account SET sessionkey = ?, last_ip = ?, last_login = NOW(), locale = ?, failed_logins = 0, os = ? WHERE username = ?", CONNECTION_SYNCH);
-    PrepareStatement(LOGIN_SEL_BNET_LAST_PLAYER_CHARACTERS, "SELECT lpc.accountId, lpc.region, lpc.battlegroup, lpc.realmId, lpc.characterName, lpc.characterGUID, lpc.lastPlayedTime FROM account_last_played_character lpc WHERE lpc.accountId = ?", CONNECTION_SYNCH);
+    PrepareStatement(LOGIN_SEL_BNET_LAST_PLAYER_CHARACTERS, "SELECT lpc.accountId, lpc.region, lpc.battlegroup, lpc.realmId, lpc.characterName, lpc.characterGUID, lpc.lastPlayedTime FROM account_last_played_character lpc INNER JOIN realmlist r ON lpc.realmId = r.id AND r.flag & 2 = 0 WHERE lpc.accountId = ?", CONNECTION_SYNCH);
     PrepareStatement(LOGIN_DEL_BNET_LAST_PLAYER_CHARACTERS, "DELETE FROM account_last_played_character WHERE accountId = ? AND region = ? AND battlegroup = ?", CONNECTION_ASYNC);
     PrepareStatement(LOGIN_INS_BNET_LAST_PLAYER_CHARACTERS, "INSERT INTO account_last_played_character (accountId, region, battlegroup, realmId, characterName, characterGUID, lastPlayedTime) VALUES (?,?,?,?,?,?,?)", CONNECTION_ASYNC);
 


### PR DESCRIPTION
It's hard to get reconnected when your last played character is on an offline realm; this filters last played characters results so they don't include offline realms. In this case, you'll see the realm selection after login.